### PR TITLE
Don't split line indexes.

### DIFF
--- a/src/parser/AbbrMarker.ts
+++ b/src/parser/AbbrMarker.ts
@@ -95,7 +95,8 @@ export class AbbrMarker implements AbstractMarker {
         const isMatchedPREPOSITIVE_ABBREVIATIONS = this.lang.PREPOSITIVE_ABBREVIATIONS.some((abbr) => {
             return compareNoCaseSensitive(abbr, currentWord);
         });
-        if (isMatchedPREPOSITIVE_ABBREVIATIONS) {
+        const isMatchedLineIndexes = /^\d+\.$/.test(currentWord);
+        if (isMatchedPREPOSITIVE_ABBREVIATIONS || isMatchedLineIndexes) {
             return sourceCode.markContextRange([sourceCode.offset, sourceCode.offset + currentWord.length]);
         }
         // ABBREVIATIONS

--- a/test/sentence-splitter-test.ts
+++ b/test/sentence-splitter-test.ts
@@ -208,6 +208,15 @@ describe("sentence-splitter", function () {
         assert.deepStrictEqual(sentences[0].loc.start, { line: 1, column: 0 });
         assert.deepStrictEqual(sentences[0].loc.end, { line: 1, column: 5 });
     });
+    it("should not split line indexes", function () {
+        const sentences = splitSentences("1. 1st text.\n2. 2nd text.");
+        assert.equal(sentences.length, 3);
+        const [sentence0, whiteSpace0, sentence1] = sentences;
+        assert.strictEqual(whiteSpace0.type, SentenceSplitterSyntax.WhiteSpace);
+        assert.strictEqual(whiteSpace0.raw, "\n");
+        assert.strictEqual(sentence0.raw, "1. 1st text.");
+        assert.strictEqual(sentence1.raw, "2. 2nd text.");
+    });
 
     describe("splitAST", () => {
         it("should handle empty child", () => {


### PR DESCRIPTION
Partly fix: https://github.com/textlint-rule/sentence-splitter/issues/35

Don't split line indexes.