### PR TITLE
BREAKING CHANGE: Drop Node.js 16 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
 name: test
 on: [push, pull_request]
-env:
-  CI: true
 jobs:
   test:
     name: "Test on Node.js ${{ matrix.node-version }}"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "keywords": [
     "text",
     "analytics",
-    "textlint"
+    "textlint",
+    "nlp"
   ],
   "homepage": "https://github.com/textlint-rule/sentence-splitter",
   "bugs": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "newLine": "LF",
     "outDir": "./module/",
-    "target": "ES2020",
+    "target": "ES2022",
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## BREAKING CHANGES

- Require Node.js 18+
  - Now, Output is ES2022.

> [!NOTE]
> No API Changes.